### PR TITLE
Modified $json_dir to reflect proper location

### DIFF
--- a/manifests/metrics.pp
+++ b/manifests/metrics.pp
@@ -48,7 +48,7 @@ define jmxtrans::metrics(
     $statsd               = undef,
     $statsd_root_prefix   = undef,
     $outfile              = undef,
-    $json_dir             = '/etc/jmxtrans',
+    $json_dir             = '/var/lib/jmxtrans',
 )
 {
     include jmxtrans


### PR DESCRIPTION
Changed $json_dir to reflect where the files truly need to belong for JMXTrans to see them. Both Debian and RPM packages require JSON files be placed in /var/lib/jmxtrans, not /etc/jmxtrans.
